### PR TITLE
Re-do readme as a high-level overview and plan

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,14 @@
 # Contributing to HTML as Custom Elements
 
+## How Can You Help?
+
+There are two main ways you can contribute:
+
+1. Contribute to the mainstream development effort! For this, see the roadmap in our readme. In particular, we need help with infrastructure and hard problems more urgently than we need to check off every element in HTML.
+2. Help us find and categorize absentee APIs! What capabilities do native HTML elements get that we don't? File an issue to discuss it, or help us organize those issues into a coherent wiki page.
+
+## Developing
+
 First, get set up. Ensure you have Chrome Canary installed, then run
 
 ```bash


### PR DESCRIPTION
Should serve a bit better as the project's public face.

(Please don't use the merge button; if you give me a LGTM I'll merge it in a straight-line history.)

Moved most of the original readme to the wiki: https://github.com/dglazkov/html-as-custom-elements/wiki/Dimitri%27s-original-README-thoughts
