### PR TITLE
Fixed Demo Scrolling Issue on Mac - Chrome Canary Build

### DIFF
--- a/demo/entry.js
+++ b/demo/entry.js
@@ -84,7 +84,7 @@ function setSelectedLink() {
 }
 
 function setHashFromScroll() {
-  const bodyScrollTop = document.body.scrollTop;
+  const bodyScrollTop = document.body.scrollTop || document.documentElement.scrollTop;
   let minDifference = +Infinity;
   let minSectionId;
   for (const section of sections) {


### PR DESCRIPTION
document.body.scrollTop was returning 0 all the time. 